### PR TITLE
Pin Solr image version to 5.5.3 

### DIFF
--- a/solr/docker-compose.yml
+++ b/solr/docker-compose.yml
@@ -1,5 +1,8 @@
 solr:
-  image: solr
+  # Pin Solr to a specific version, because the latest versions
+  # of Solr (>= 6.0.0) are not compatible with the Solr config
+  # in this example.
+  image: solr:5.5.3
   labels:
     com.dnsdock.name: "solr"
     com.dnsdock.image: "outrigger"

--- a/solr/docker-compose.yml
+++ b/solr/docker-compose.yml
@@ -2,7 +2,7 @@ solr:
   # Pin Solr to a specific version, because the latest versions
   # of Solr (>= 6.0.0) are not compatible with the Solr config
   # in this example.
-  image: solr:5.5.3
+  image: solr:5.5
   labels:
     com.dnsdock.name: "solr"
     com.dnsdock.image: "outrigger"


### PR DESCRIPTION
The example currently doesn't seem to be working due to compatibility issues with configuration structure in Solr 5 vs Solr 6. So for now, pinning the Solr image to 5.5.3 so that the example works.

I looked to see if I could identify the source of the problem, but nothing jumped out:

https://cwiki.apache.org/confluence/display/solr/Major+Changes+from+Solr+5+to+Solr+6