### PR TITLE
NOMERGE: Updates to Solr example

### DIFF
--- a/solr/docker-compose.yml
+++ b/solr/docker-compose.yml
@@ -1,8 +1,7 @@
 solr:
-  # Pin Solr to a specific version, because the latest versions
-  # of Solr (>= 6.0.0) are not compatible with the Solr config
-  # in this example.
-  image: solr:5.5
+  build: env/docker/solr
+  ports:
+    - "8983:8983"
   labels:
     com.dnsdock.name: "solr"
     com.dnsdock.image: "outrigger"
@@ -13,12 +12,4 @@ solr:
   volumes:
     - ./env/solr/core01:/opt/solr/server/solr/core01
     - ./env/solr/core02:/opt/solr/server/solr/core02
-  volumes_from:
-    - solr_data
-# This container exists to allow for setting the data area of solr to
-# a persistant storage area and fixing permissions so that the solr
-# container can write to it. This does not need to be done per core
-solr_data:
-  build: ./dockerfiles/solr_data
-  volumes:
-    - /data/solr_example/solr:/var/lib/solr
+    - /data/outrigger/solr:/var/lib/solr

--- a/solr/dockerfiles/solr_data/Dockerfile
+++ b/solr/dockerfiles/solr_data/Dockerfile
@@ -1,4 +1,0 @@
-# use phase2/servicebase which is already set up for fix-attrs.d
-FROM phase2/servicebase
-VOLUME ["/var/lib/solr"]
-ADD root /

--- a/solr/dockerfiles/solr_data/root/etc/fix-attrs.d/10-solr-data
+++ b/solr/dockerfiles/solr_data/root/etc/fix-attrs.d/10-solr-data
@@ -1,5 +1,0 @@
-# As a last resort the permission can be set to 777 but the user
-# and UID should match up with the user the solr process runs as
-# in the solr container, generally the UID is what is needed to
-# set correctly in order to allow writing successfully
-/var/lib/solr false solr,8983 0755

--- a/solr/env/docker/solr/Dockerfile
+++ b/solr/env/docker/solr/Dockerfile
@@ -1,0 +1,10 @@
+FROM solr:5.5.4
+
+# In order to perform filesystem operations outside of SOLR_USER control.
+USER root
+
+# Create and permission the data directory.
+RUN mkdir -pv /var/lib/solr && chown -R $SOLR_USER:$SOLR_USER /var/lib/solr
+
+# Restore use of the Solr user for container operations.
+USER $SOLR_USER


### PR DESCRIPTION
This moves us from 2 containers for Solr down to 1.

Current problem is that the permissions changes in the Dockerfile don't seem to be doing the job, because when `docker-compose up`'ing, you get:

```
solr_1  | 1958 ERROR (coreLoadExecutor-6-thread-2) [   x:core01] o.a.s.c.SolrCore :java.nio.file.AccessDeniedException: /var/lib/solr/core01
```

Any thoughts on that? Or, is this approach just entirely wrong to begin with? 